### PR TITLE
Bump ethereum-tx version for npm install to work.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "browser-request": "",
         "crypto-js": ">=3.1",
         "enum": "",
-        "ethereumjs-tx": "0.5.5",
+        "ethereumjs-tx": "0.6.7",
         "ethereumjs-util": "",
         "request": "",
         "string": ""


### PR DESCRIPTION
This was not working on OS X for me. (10.10.5)

Bumping the version fixed this.